### PR TITLE
feat(ci) - Continuous Integration Pipeline

### DIFF
--- a/ci/assets/azure/azuredeploy.json
+++ b/ci/assets/azure/azuredeploy.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "allowedValues": [
+        "East Asia",
+        "Southeast Asia",
+        "Central US",
+        "East US",
+        "East US 2",
+        "West US",
+        "North Central US",
+        "South Central US",
+        "North Europe",
+        "West Europe",
+        "Japan West",
+        "Japan East",
+        "Brazil South",
+        "Australia East",
+        "Australia Southeast"
+      ],
+      "metadata": {
+        "description": "Location to deploy to"
+      }
+    },
+    "newStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. It must be between 3 and 24 characters in length and use numbers and lower-case letters only."
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "boshvnet-crp",
+      "metadata": {
+        "description": "name of the virtual network"
+      }
+    },
+    "virtualNetworkPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "the CIDR block of the azure virtual network"
+      }
+    },
+    "subnetNameForBosh": {
+      "type": "string",
+      "defaultValue": "Bosh",
+      "metadata": {
+        "description": "name of the subnet for Bosh"
+      }
+    },
+    "subnetNameForCloudFoundry": {
+      "type": "string",
+      "defaultValue": "CloudFoundry",
+      "metadata": {
+        "description": "name of the subnet for CloudFoundy"
+      }
+    }
+  },
+  "variables": {
+    "pubIPBaseName" : "pubIP",
+    "api-version": "2015-05-01-preview",
+    "vmStorageAccountContainerName": "vhds",
+    "storageAccountType": "Standard_LRS",
+    "storageid": "[resourceId('Microsoft.Storage/storageAccounts', parameters('newStorageAccountName'))]",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
+    "addressPrefix": "[parameters('virtualNetworkPrefix')]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+    "subnet1Name": "[parameters('subnetNameForBosh')]",
+    "subnet1Prefix": "10.0.0.0/24",
+    "subnet1Ref": "[concat(variables('vnetID'),'/subnets/', variables('subnet1Name'))]",
+    "subnet2Name": "[parameters('subnetNameForCloudFoundry')]",
+    "subnet2Prefix": "10.0.16.0/24",
+    "devboxPrivateIPAddress": "10.0.0.100",
+    "imagePublisher": "Canonical",
+    "imageOffer": "UbuntuServer",
+    "ubuntuOSVersion": "14.04.2-LTS",
+    "repository": "Azure",
+    "branch": "master",
+    "githubPath": "[concat('https://raw.githubusercontent.com/', variables('repository'), '/azure-quickstart-templates/', variables('branch'), '/bosh-setup/')]",
+    "cloudfoundryBlob": "http://cloudfoundry.blob.core.windows.net/misc/"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('newStorageAccountName')]",
+      "apiVersion": "[variables('api-version')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "[variables('api-version')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(variables('pubIPBaseName'),'-bosh')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "static"
+      }
+    },
+    {
+      "apiVersion": "[variables('api-version')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(variables('pubIPBaseName'), '-cf')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "static"
+      }
+    },
+    {
+      "apiVersion": "[variables('api-version')]",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnet1Name')]",
+            "properties": {
+              "addressPrefix": "[variables('subnet1Prefix')]"
+            }
+          },
+          {
+            "name": "[variables('subnet2Name')]",
+            "properties": {
+              "addressPrefix": "[variables('subnet2Prefix')]"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/ci/docker/Vagrantfile
+++ b/ci/docker/Vagrantfile
@@ -1,0 +1,24 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider(:virtualbox) do |v|
+    v.name = 'bosh-aws-cpi-release-docker-builder'
+    v.customize ['modifyvm', :id, '--cpus', '4']
+    v.customize ['modifyvm', :id, '--memory', '4096']
+  end
+
+  config.vm.provision :shell do |shell|
+    shell.inline = <<-BASH
+      apt-get -y update
+    BASH
+  end
+
+  config.vm.provision('docker')
+  config.vm.synced_folder "../../", "/vagrant/bosh.aws-cpi-release/cpi-release"
+end

--- a/ci/docker/bosh.azure-cpi-release/Dockerfile
+++ b/ci/docker/bosh.azure-cpi-release/Dockerfile
@@ -1,0 +1,43 @@
+FROM node:latest
+
+RUN apt-get update; apt-get -y upgrade; apt-get clean
+
+RUN apt-get install -y git curl wget tar make; apt-get clean
+
+RUN apt-get install -y sqlite3 libsqlite3-dev; apt-get clean
+
+RUN apt-get install -y mysql-client libmysqlclient-dev; apt-get clean
+
+RUN apt-get install -y jq; apt-get clean
+
+RUN apt-get install -y postgresql-9.3 postgresql-client-9.3 libpq-dev; apt-get clean
+
+RUN apt-get install -y sudo; apt-get clean
+
+# azure command line
+RUN npm install -g azure-cli
+
+# chruby
+RUN mkdir /tmp/chruby && \
+    cd /tmp && \
+    curl https://codeload.github.com/postmodern/chruby/tar.gz/v0.3.9 | tar -xz && \
+    cd /tmp/chruby-0.3.9 && \
+    sudo ./scripts/setup.sh && \
+    rm -rf /tmp/chruby
+
+# ruby-install
+RUN mkdir /tmp/ruby-install && \
+    cd /tmp && \
+    curl https://codeload.github.com/postmodern/ruby-install/tar.gz/v0.5.0 | tar -xz && \
+    cd /tmp/ruby-install-0.5.0 && \
+    sudo make install && \
+    rm -rf /tmp/ruby-install
+
+# ruby
+RUN ruby-install ruby 2.1.2
+
+# Bundler and BOSH CLI
+RUN /bin/bash -l -c "source /etc/profile.d/chruby.sh ;  \
+                     chruby 2.1.2 ;                     \
+                     gem install bundler bosh_cli --no-ri --no-rdoc"
+

--- a/ci/docker/bosh.azure-cpi-release/build-image.sh
+++ b/ci/docker/bosh.azure-cpi-release/build-image.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+DOCKER_IMAGE=${DOCKER_IMAGE:-sedouard/azure-cpi-release}
+
+docker login
+
+echo "Building docker image..."
+docker build -t $DOCKER_IMAGE .
+
+echo "Pushing docker image..."
+docker push $DOCKER_IMAGE
+

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,222 @@
+---
+groups:
+  - name: bosh-azure-cpi-release
+    jobs:
+      - build-candidate
+      - azure-ubuntu
+      - deploy-director
+      - bats-ubuntu
+      - promote-candidate
+jobs:
+- name: build-candidate
+  serial: true
+  plan:
+  - aggregate:
+    - {trigger: false, get: bosh-cpi-release, resource: bosh-cpi-release-in}
+    - {trigger: false, get: version-semver, params: {bump: patch}}
+
+  - put: version-semver
+    params: {file: version-semver/number}
+
+  - task: build
+    file: bosh-cpi-release/ci/tasks/build-candidate.yml
+
+  - put: bosh-cpi-dev-artifacts
+    params: {from: build/out/.*\.tgz}
+
+- name: azure-ubuntu
+  serial: true
+  plan:
+  - aggregate:
+    - {trigger: false, get: bosh-cpi-release, resource: bosh-cpi-release-in}
+
+  - task: azure-provision
+    file: bosh-cpi-release/ci/tasks/azure-provision.yml
+    config:
+      params:
+        AZURE_CLIENT_ID:          {{azure_client_id}}
+        AZURE_CLIENT_SECRET:      {{azure_client_secret}}
+        AZURE_TENANT_ID: {{azure_tenant_id}}
+        AZURE_GROUP_NAME: {{azure_group_name}}
+        AZURE_REGION_NAME: {{azure_region_name}}
+        AZURE_VNET_NAME: {{azure_vnet_name}}
+        AZURE_REGION_SHORT_NAME: {{azure_region_short_name}}
+        AZURE_STORAGE_ACCOUNT_NAME: {{azure_storage_account_name}}
+        AZURE_SUBSCRIPTION_ID: {{azure_subscription_id}}
+        AZURE_TENANT_ID: {{azure_tenant_id}}
+        AZURE_BOSH_SUBNET_NAME: {{azure_bosh_subnet_name}}
+        AZURE_CF_SUBNET_NAME: {{azure_cf_subnet_name}}
+        base_os:                    ubuntu
+    ensure:
+      do:
+      - put: azure-exports
+        params: {from: azure-provision/azure-exports.sh$}
+
+- name: deploy-director
+  serial: true # find out serial vs. serial_groups and which previous job should trigger this job
+  plan:
+  - aggregate:
+    - {trigger: false,  passed: [build-candidate],  get: bosh-cpi-dev-artifacts, resource: bosh-cpi-dev-artifacts}
+    - {trigger: false, passed: [build-candidate],  get: version-semver, resource: version-semver}
+    - {trigger: true,  passed: [azure-ubuntu],     get: azure-exports, resource: azure-exports}
+    - {trigger: false,  get: bosh-cpi-release, resource: bosh-cpi-release-in}
+    - {trigger: false,                             get: director-state-file, resource: ubuntu-director-state-file}
+    - {trigger: false,                             get: bosh-init}
+    - {trigger: false,                             get: bosh-release}
+
+  - task: deploy
+    file: bosh-cpi-release/ci/tasks/deploy.yml
+    config:
+      params:
+        base_os:                    ubuntu
+        AZURE_CLIENT_ID:            {{azure_client_id}}
+        AZURE_CLIENT_SECRET:        {{azure_client_secret}}
+        AZURE_TENANT_ID:            {{azure_tenant_id}}
+        AZURE_GROUP_NAME:           {{azure_group_name}}
+        AZURE_VNET_NAME:            {{azure_vnet_name}}
+        AZURE_STORAGE_ACCOUNT_NAME: {{azure_storage_account_name}}
+        AZURE_SUBSCRIPTION_ID:      {{azure_subscription_id}}
+        AZURE_BOSH_SUBNET_NAME:     {{azure_bosh_subnet_name}}
+        BAT_NETWORK_GATEWAY:        {{BAT_NETWORK_GATEWAY}}
+        STEMCELL_URL:               {{BAT_STEMCELL_URL_UBUNTU}}
+        STEMCELL_SHA:               {{BAT_STEMCELL_SHA_UBUNTU}}
+        private_key_data:           {{bosh_private_key}}
+        ssh_certificate:            {{bosh_public_cert}}
+    ensure:
+      do:
+      - put: ubuntu-director-state-file
+        params: {from: deploy/director-state-file/ubuntu-director-manifest-state.json}
+
+- name: promote-candidate
+  serial: true
+  plan:
+  - aggregate:
+    # TODO: After the bosh-init and bats tasks are implemented, we should
+    # be able to add
+    - {trigger: true, passed: [build-candidate], passed: [bats-ubuntu], get: bosh-cpi-dev-artifacts}
+    - {trigger: false, get: bosh-cpi-release, resource: bosh-cpi-release-in}
+
+  - task: promote
+    file: bosh-cpi-release/ci/tasks/promote-candidate.yml
+    config:
+      params:
+        aws_access_key_id: {{s3_azure_cpi_access_key}}
+        aws_secret_access_key: {{s3_azure_cpi_secret_key}}
+
+  - put: bosh-cpi-release
+    resource: bosh-cpi-release-out
+    params: {repository: promote/bosh-cpi-release, rebase: true}
+
+- name: bats-ubuntu
+  plan:
+  #  
+  # passed: 
+  - aggregate:
+    - {trigger: true, passed: [build-candidate], passed: [deploy-director], get: bosh-cpi-dev-artifacts}
+    - {trigger: false, get: bosh-cpi-release, resource: bosh-cpi-release-in}
+    - {trigger: false, passed: [azure-ubuntu], get: azure-exports, resource: azure-exports}
+    - {trigger: false, get: bosh}
+    - {trigger: false, get: stemcell, resource: azure-ubuntu-stemcell}
+
+  - task: test
+    file: bosh-cpi-release/ci/tasks/run-bats.yml
+    config:
+      params:
+        base_os:                    ubuntu
+        BAT_VCAP_PASSWORD:          {{BAT_VCAP_PASSWORD}}
+        private_key_data:           {{bosh_private_key}}
+        AZURE_VNET_NAME:            {{azure_vnet_name}}
+        BAT_STEMCELL_URL:           {{BAT_STEMCELL_URL_UBUNTU}}
+        BAT_STEMCELL_SHA:           {{BAT_STEMCELL_SHA_UBUNTU}}
+        BAT_SECOND_STATIC_IP:       {{BAT_SECOND_STATIC_IP}}
+        BAT_NETWORK_STATIC_IP:      {{BAT_NETWORK_STATIC_IP}}
+        BAT_NETWORK_CIDR:           {{BAT_NETWORK_CIDR}}
+        BAT_NETWORK_RESERVED_RANGE: {{BAT_NETWORK_RESERVED_RANGE}}
+        BAT_NETWORK_GATEWAY:        {{BAT_NETWORK_GATEWAY}}
+        BAT_NETWORK_STATIC_RANGE:   {{BAT_NETWORK_STATIC_RANGE}}
+        AZURE_CF_SUBNET_NAME: {{azure_cf_subnet_name}}
+
+resources:
+- name: bosh-cpi-release-in
+  type: git
+  source:
+    uri: {{azure_cpi_bosh_release_repo}}
+    branch: {{azure_cpi_bosh_release_branch}}
+    private_key: {{github_deployment_key__bosh-azure-cpi-release}}
+    ignore_paths:
+        - .final_builds/**/*.yml
+        - releases/**/*.yml
+
+- name: bosh-cpi-release-out
+  type: git
+  source:
+    uri: {{azure_cpi_bosh_release_repo}}
+    branch: {{github_deployment_branch}}
+    private_key: {{github_deployment_key__bosh-azure-cpi-release}}
+
+- name: version-semver
+  type: semver
+  source:
+    key:               current-version # dev-release version
+    initial_version:   0.0.1
+    bucket:            {{s3_azure_cpi_pipeline_bucket}}
+    access_key_id:     {{s3_azure_cpi_access_key}}
+    secret_access_key: {{s3_azure_cpi_secret_key}}
+
+- name: bosh-cpi-dev-artifacts
+  type: s3
+  source:
+    regexp: bosh-azure-cpi\.tgz
+    bucket: {{s3_azure_cpi_pipeline_bucket}}
+    region_name: {{s3_azure_cpi_region}}
+    access_key_id: {{s3_azure_cpi_access_key}}
+    secret_access_key: {{s3_azure_cpi_secret_key}}
+
+- name: bosh-init
+  type: s3
+  source:
+    versioned_file: bosh-init-linux-amd64
+    bucket: {{s3_bosh_init_bucket}}
+    region_name: {{s3_azure_state_file_region}}
+    access_key_id: {{s3_azure_state_file_access_key}}
+    secret_access_key: {{s3_azure_state_file_secret_key}}
+
+- name: ubuntu-director-state-file
+  type: s3
+  source:
+    bucket:            {{s3_azure_cpi_ubuntu_director_state_file_bucket}}
+    versioned_file:    ubuntu-director-manifest-state.json
+    region_name:       {{s3_azure_cpi_ubuntu_director_state_file_region}}
+    access_key_id:     {{s3_azure_cpi_ubuntu_director_state_file_access_key}}
+    secret_access_key: {{s3_azure_cpi_ubuntu_director_state_file_secret_key}}
+
+- name: azure-exports
+  type: s3
+  source:
+    versioned_file: azure-exports.sh
+    bucket: {{s3_azure_state_file_bucket}}
+    region_name: {{s3_azure_state_file_region}}
+    access_key_id: {{s3_azure_state_file_access_key}}
+    secret_access_key: {{s3_azure_state_file_secret_key}}
+
+- name: bosh-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry/bosh
+
+
+# TODO used bats repo directly
+- name: bosh
+  type: git
+  source:
+    uri:  https://github.com/AbelHu/bosh
+    branch: abelhu
+
+- name: azure-ubuntu-stemcell
+  type: s3
+  source:
+    bucket: {{s3_temp_stemcell_bucket}}
+    versioned_file: stemcell.tgz
+    region_name: {{s3_azure_cpi_region}}
+    access_key_id: {{s3_azure_cpi_access_key}}
+    secret_access_key: {{s3_azure_cpi_secret_key}}

--- a/ci/tasks/azure-provision.sh
+++ b/ci/tasks/azure-provision.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+source bosh-cpi-release/ci/tasks/utils.sh
+
+# copy 
+cp bosh-cpi-release/ci/assets/azure/azuredeploy.json ./azuredeploy.json
+pwd
+check_param AZURE_CLIENT_ID
+check_param AZURE_CLIENT_SECRET
+check_param AZURE_GROUP_NAME
+check_param AZURE_REGION_NAME
+check_param AZURE_REGION_SHORT_NAME
+check_param AZURE_BOSH_SUBNET_NAME
+check_param AZURE_CF_SUBNET_NAME
+check_param AZURE_TENANT_ID
+
+azure login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
+
+# switch to resource manager mode
+echo "azure config mode arm"
+azure config mode arm
+export_file=azure-exports.sh
+# check if group already exists
+echo "azure group list | grep ${AZURE_GROUP_NAME}"
+azure group list | grep ${AZURE_GROUP_NAME}
+
+if [ $? -eq 0 ]
+then
+	echo "azure group delete ${AZURE_GROUP_NAME}"
+	azure group delete ${AZURE_GROUP_NAME} --quiet
+	echo "waiting for delete operation to finish..."
+	# wait for resource group to delet 
+	azure group show ${AZURE_GROUP_NAME}
+	while [ $? -eq 0 ]
+	do
+		azure group show ${AZURE_GROUP_NAME} > /dev/null 2>&1
+		echo "..."
+	done
+fi
+
+echo azure group create ${AZURE_GROUP_NAME} ${AZURE_REGION_SHORT_NAME}
+azure group create ${AZURE_GROUP_NAME} ${AZURE_REGION_SHORT_NAME}
+echo "{ \"location\": { \"value\": \"${AZURE_REGION_NAME}\" }, \"newStorageAccountName\": { \"value\": \"${AZURE_STORAGE_ACCOUNT_NAME}\" }, \"virtualNetworkName\": { \"value\": \"${AZURE_VNET_NAME}\" }, \"subnetNameForBosh\": { \"value\": \"${AZURE_BOSH_SUBNET_NAME}\" }, \"subnetNameForCloudFoundry\": { \"value\": \"${AZURE_CF_SUBNET_NAME}\" } }" > azuredeploy-parameters.json
+cat ./azuredeploy-parameters.json
+azure group deployment create ${AZURE_GROUP_NAME} --template-file ./azuredeploy.json --parameters-file ./azuredeploy-parameters.json
+
+#setup storage account containers
+azure storage container create --account-name ${AZURE_STORAGE_ACCOUNT_NAME} --account-key $(azure storage account keys list ${AZURE_STORAGE_ACCOUNT_NAME} -g ${AZURE_GROUP_NAME} --json | jq '.storageAccountKeys.key1' -r) --container bosh
+azure storage container create --account-name ${AZURE_STORAGE_ACCOUNT_NAME} --account-key $(azure storage account keys list ${AZURE_STORAGE_ACCOUNT_NAME} -g ${AZURE_GROUP_NAME} --json | jq '.storageAccountKeys.key1' -r) --container stemcell
+
+echo -e "export DIRECTOR=$(azure network public-ip show ${AZURE_GROUP_NAME} pubIP-bosh --json | jq '.ipAddress')" >> $export_file
+echo -e "export CF_IP_ADDRESS=$(azure network public-ip show ${AZURE_GROUP_NAME} pubIP-cf --json | jq '.ipAddress')" >> $export_file
+echo -e "export AZURE_STORAGE_ACCESS_KEY=$(azure storage account keys list ${AZURE_STORAGE_ACCOUNT_NAME} -g ${AZURE_GROUP_NAME} --json | jq '.storageAccountKeys.key1' -r)" >> $export_file

--- a/ci/tasks/azure-provision.yml
+++ b/ci/tasks/azure-provision.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+image: docker:///sedouard/azure-cpi-release
+inputs:
+  - name: bosh-cpi-release
+run:
+  path: bosh-cpi-release/ci/tasks/azure-provision.sh
+params:
+    AZURE_CLIENT_ID:          replace-me
+    AZURE_CLIENT_SECRET:      replace-me
+    AZURE_TENANT_ID: replace-me
+    AZURE_GROUP_NAME: replace-me
+    AZURE_REGION_NAME: replace-me
+    AZURE_VNET_NAME: replace-me
+    AZURE_REGION_SHORT_NAME: replace-me
+    AZURE_STORAGE_ACCOUNT_NAME: replace-me
+    AZURE_SUBSCRIPTION_ID: replace-me
+    AUZRE_BOSH_SUBNET_NAME: replace-me
+    AZURE_CF_SUBNET_NAME: replace-me

--- a/ci/tasks/build-candidate.sh
+++ b/ci/tasks/build-candidate.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+source /etc/profile.d/chruby.sh
+chruby 2.1.2
+
+semver=`cat version-semver/number`
+
+mkdir out
+
+cd bosh-cpi-release
+
+echo "using bosh CLI version..."
+bosh version
+
+cpi_release_name="bosh-azure-cpi"
+
+echo "building CPI release..."
+bosh create release --name $cpi_release_name --version $semver --with-tarball
+
+mv dev_releases/$cpi_release_name/$cpi_release_name-$semver.tgz ../out/

--- a/ci/tasks/build-candidate.yml
+++ b/ci/tasks/build-candidate.yml
@@ -1,0 +1,8 @@
+---
+platform: linux
+image: docker:///sedouard/azure-cpi-release
+inputs:
+  - name: bosh-cpi-release
+  - name: version-semver
+run:
+  path: bosh-cpi-release/ci/tasks/build-candidate.sh

--- a/ci/tasks/deploy.sh
+++ b/ci/tasks/deploy.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+
+set -e
+echo "deploy.sh..."
+source bosh-cpi-release/ci/tasks/utils.sh
+source azure-exports/azure-exports.sh
+
+check_param AZURE_CLIENT_ID
+check_param AZURE_CLIENT_SECRET
+check_param AZURE_TENANT_ID
+check_param AZURE_GROUP_NAME
+check_param AZURE_VNET_NAME
+check_param AZURE_STORAGE_ACCOUNT_NAME
+check_param AZURE_SUBSCRIPTION_ID
+check_param AZURE_BOSH_SUBNET_NAME
+check_param base_os
+check_param private_key_data
+check_param ssh_certificate
+check_param DIRECTOR
+check_param AZURE_STORAGE_ACCESS_KEY
+check_param BAT_NETWORK_GATEWAY
+check_param STEMCELL_URL
+check_param STEMCELL_SHA
+
+echo "Checking params from previous steps..."
+echo "show directory ip..."
+echo "$DIRECTOR"
+
+source /etc/profile.d/chruby.sh
+chruby 2.1.2
+
+semver=`cat version-semver/number`
+cpi_release_name=bosh-azure-cpi
+working_dir=$PWD
+manifest_dir="${working_dir}/director-state-file"
+manifest_filename=${manifest_dir}/${base_os}-director-manifest.yml
+
+mkdir -p $manifest_dir/keys
+echo "$private_key_data" > $manifest_dir/keys/bats.pem
+
+eval $(ssh-agent)
+chmod go-r $manifest_dir/keys/bats.pem
+ssh-add $manifest_dir/keys/bats.pem
+
+#create director manifest as heredoc
+cat > "${manifest_filename}"<<EOF
+---
+name: bosh
+
+releases:
+- name: bosh
+  url: http://cloudfoundry.blob.core.windows.net/azureci/bosh-214+dev.1.tgz
+  sha1: c28477c7e08cce06add980bed0ab1ab113a7c825
+- name: bosh-azure-cpi
+  url: file://tmp/bosh-azure-cpi.tgz
+
+networks:
+- name: public
+  type: vip
+  cloud_properties:
+    tcp_endpoints:
+    - "22:22"
+    - "4222:4222"
+    - "6868:6868"
+    - "25250:25250"
+    - "25555:25555"
+    - "25777:25777"
+    udp_endpoints:
+    - "68:68"
+    - "53:53"
+- name: private
+  type: manual
+  subnets:
+  - range: 10.0.0.0/24
+    gateway: 10.0.0.1
+    dns: [8.8.8.8]
+    cloud_properties:
+      virtual_network_name: $AZURE_VNET_NAME
+      subnet_name: $AZURE_BOSH_SUBNET_NAME
+
+resource_pools:
+- name: vms
+  network: private
+  stemcell:
+    url: $STEMCELL_URL
+    sha1: $STEMCELL_SHA
+  cloud_properties:
+    instance_type: Standard_D1
+
+disk_pools:
+- name: disks
+  disk_size: 25_000
+
+jobs:
+- name: bosh
+  templates:
+  - {name: powerdns, release: bosh}
+  - {name: nats, release: bosh}
+  - {name: redis, release: bosh}
+  - {name: postgres, release: bosh}
+  - {name: blobstore, release: bosh}
+  - {name: director, release: bosh}
+  - {name: health_monitor, release: bosh}
+  - {name: registry, release: bosh}
+  - {name: cpi, release: bosh-azure-cpi}
+
+  instances: 1
+  resource_pool: vms
+  persistent_disk_pool: disks
+
+  networks:
+  - {name: private, static_ips: [10.0.0.10], default: [dns, gateway]}
+  - {name: public, static_ips: [$DIRECTOR]}
+
+  properties:
+    nats:
+      address: 127.0.0.1
+      user: nats
+      password: nats-password
+
+    redis:
+      listen_addresss: 127.0.0.1
+      address: 127.0.0.1
+      password: redis-password
+
+    postgres: &db
+      host: 127.0.0.1
+      user: postgres
+      password: postgres-password
+      database: bosh
+      adapter: postgres
+
+    dns:
+      address: $DIRECTOR
+      db:
+        user: postgres
+        password: postgres-password
+        host: 127.0.0.1
+        listen_address: 127.0.0.1
+        database: bosh
+      user: powerdns
+      password: powerdns
+      database:
+        name: powerdns
+      webserver:
+        password: powerdns
+      replication:
+        basic_auth: replication:zxKDUBeCfKYXk
+        user: replication
+        password: powerdns
+      recursor: $DIRECTOR
+
+    # Tells the Director/agents how to contact registry
+    registry:
+      address: 10.0.0.10
+      host: 10.0.0.10
+      db: *db
+      http: {user: admin, password: admin, port: 25777}
+      username: admin
+      password: admin
+      port: 25777
+
+    # Tells the Director/agents how to contact blobstore
+    blobstore:
+      address: 10.0.0.10
+      port: 25250
+      provider: dav
+      director: {user: director, password: director-password}
+      agent: {user: agent, password: agent-password}
+
+    director:
+      address: 127.0.0.1
+      name: bosh
+      db: *db
+      cpi_job: cpi
+      enable_snapshots: true
+      timeout: "180s"
+
+    hm:
+      http: {user: hm, password: hm-password}
+      director_account: {user: admin, password: admin}
+
+    azure: &azure
+      environment: AzureCloud
+      subscription_id: $AZURE_SUBSCRIPTION_ID
+      storage_account_name: $AZURE_STORAGE_ACCOUNT_NAME
+      storage_access_key: $AZURE_STORAGE_ACCESS_KEY
+      resource_group_name: $AZURE_GROUP_NAME
+      tenant_id: $AZURE_TENANT_ID
+      client_id: $AZURE_CLIENT_ID
+      client_secret: $AZURE_CLIENT_SECRET
+      ssh_user: vcap
+      ssh_certificate: | 
+        $ssh_certificate
+
+    # Tells agents how to contact nats
+    agent: {mbus: "nats://nats:nats-password@10.0.0.10:4222"}
+
+    ntp: &ntp [0.north-america.pool.ntp.org]
+
+cloud_provider:
+  template: {name: cpi, release: bosh-azure-cpi}
+
+  # Tells bosh-init how to SSH into deployed VM
+  ssh_tunnel:
+    host: $DIRECTOR
+    #host: 10.0.0.10
+    port: 22
+    user: vcap
+    private_key: $manifest_dir/keys/bats.pem
+
+  # Tells bosh-init how to contact remote agent
+  mbus: https://mbus-user:mbus-password@$DIRECTOR:6868
+#  mbus: https://mbus-user:mbus-password@10.0.0.10:6868
+
+  properties:
+    azure: *azure
+
+    # Tells CPI how agent should listen for bosh-init requests
+    agent: {mbus: "https://mbus-user:mbus-password@0.0.0.0:6868"}
+
+    blobstore: {provider: local, path: /var/vcap/micro_bosh/data/cache}
+
+    ntp: *ntp
+
+EOF
+
+echo "normalizing paths to match values referenced in $manifest_filename"
+# manifest paths are now relative so the tmp inputs need to be updated
+mkdir ${manifest_dir}/../tmp
+echo copying cpi...
+echo cp ./bosh-cpi-dev-artifacts/${cpi_release_name}-${semver}.tgz ${manifest_dir}/../tmp/${cpi_release_name}.tgz
+cp ./bosh-cpi-dev-artifacts/${cpi_release_name}-${semver}.tgz ${manifest_dir}/../tmp/${cpi_release_name}.tgz
+#cp ./bosh-release/release.tgz ${manifest_dir}/tmp/bosh-release.tgz ##TODO
+#cp ./stemcell/stemcell.tgz ${manifest_dir}/tmp/stemcell.tgz ##TODO
+
+initexe="$PWD/bosh-init/bosh-init-linux-amd64"
+chmod +x $initexe
+
+echo "using bosh-init CLI version..."
+$initexe version
+
+cat $manifest_filename
+echo "deleting existing BOSH Director VM..."
+$initexe delete $manifest_filename
+#TODO: debug purpose, remove after this is official
+export BOSH_INIT_LOG_LEVEL='Debug'
+export BOSH_INIT_LOG_PATH='./run.log'
+echo "deploying BOSH..."
+
+$initexe deploy $manifest_filename

--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -1,0 +1,28 @@
+---
+platform: linux
+image: docker:///sedouard/azure-cpi-release
+inputs:
+  - name: bosh-cpi-dev-artifacts # -++ used for deployment manifest referenced by manifest_path
+  - name: version-semver         # -//
+  - name: director-state-file
+  - name: bosh-cpi-release
+  - name: bosh-init              # --- bosh-init executable to do deploy
+  - name: bosh-release           # -\
+  - name: azure-exports          # -/
+run:
+  path: bosh-cpi-release/ci/tasks/deploy.sh
+params:
+  base_os:                    replace-me
+  AZURE_CLIENT_ID:            replace-me
+  AZURE_CLIENT_SECRET:        replace-me
+  AZURE_TENANT_ID:            replace-me
+  AZURE_GROUP_NAME:           replace-me
+  AZURE_VNET_NAME:            replace-me
+  AZURE_STORAGE_ACCOUNT_NAME: replace-me
+  AZURE_SUBSCRIPTION_ID:      replace-me
+  AZURE_BOSH_SUBNET_NAME:     replace-me
+  BAT_NETWORK_GATEWAY:        replace-me
+  private_key_data:           replace-me
+  ssh_certificate:            replace-me
+  STEMCELL_URL:               replace-me
+  STEMCELL_SHA:               replace-me

--- a/ci/tasks/promote-candidate.sh
+++ b/ci/tasks/promote-candidate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+source bosh-cpi-release/ci/tasks/utils.sh
+
+cd bosh-cpi-release
+
+source /etc/profile.d/chruby.sh
+chruby 2.1.2
+
+set +x
+echo creating config/private.yml with blobstore secrets
+cat > config/private.yml << EOF
+---
+blobstore:
+  s3:
+    access_key_id: $aws_access_key_id
+    secret_access_key: $aws_secret_access_key
+EOF
+set -x
+
+echo "using bosh CLI version..."
+bosh version
+
+echo "finalizing CPI release..."
+bosh finalize release ../bosh-cpi-dev-artifacts/*.tgz
+
+rm config/private.yml
+
+version=`git diff releases/*/index.yml | grep -E "^\+.+version" | sed s/[^0-9]*//g`
+git diff | cat
+git add .
+
+git config --global user.email cf-bosh-eng@pivotal.io
+git config --global user.name CI
+git commit -m "New final release v $version"

--- a/ci/tasks/promote-candidate.yml
+++ b/ci/tasks/promote-candidate.yml
@@ -1,0 +1,11 @@
+---
+platform: linux
+image: docker:///sedouard/azure-cpi-release
+inputs:
+  - name: bosh-cpi-release
+  - name: bosh-cpi-dev-artifacts
+run:
+  path: bosh-cpi-release/ci/tasks/promote-candidate.sh
+params:
+  aws_access_key_id:     replace-me
+  aws_secret_access_key: replace-me

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+set -e
+
+source bosh-cpi-release/ci/tasks/utils.sh
+source azure-exports/azure-exports.sh
+check_param base_os
+check_param private_key_data
+check_param BAT_VCAP_PASSWORD
+check_param BAT_SECOND_STATIC_IP
+check_param BAT_NETWORK_CIDR
+check_param BAT_NETWORK_RESERVED_RANGE
+check_param BAT_NETWORK_STATIC_RANGE
+check_param BAT_NETWORK_GATEWAY
+check_param BAT_NETWORK_STATIC_IP
+check_param BAT_STEMCELL_URL
+check_param BAT_STEMCELL_SHA
+check_param AZURE_VNET_NAME
+check_param AZURE_CF_SUBNET_NAME
+check_param CF_IP_ADDRESS
+#TODO: debug purpose, remove after this is official
+export LOG_LEVEL='Debug'
+export LOG_PATH='./run.log'
+source /etc/profile.d/chruby.sh
+chruby 2.1.2
+
+
+
+echo "DirectorIP =" $DIRECTOR
+
+mkdir -p $PWD/keys
+echo "$private_key_data" > $PWD/keys/bats.pem
+eval $(ssh-agent)
+chmod go-r $PWD/keys/bats.pem
+ssh-add $PWD/keys/bats.pem
+
+export BAT_DIRECTOR=$DIRECTOR
+export BAT_DNS_HOST=$DIRECTOR
+export BAT_STEMCELL="${PWD}/stemcell/stemcell.tgz"
+export BAT_DEPLOYMENT_SPEC="${PWD}/${base_os}-bats-config.yml"
+export BAT_VCAP_PASSWORD=$BAT_VCAP_PASSWORD
+export BAT_VCAP_PRIVATE_KEY=$PWD/keys/bats.pem
+export BAT_INFRASTRUCTURE=azure
+export BAT_NETWORKING=manual
+
+bosh -n target $BAT_DIRECTOR
+echo Using This version of bosh:
+bosh --version
+cat > "${BAT_DEPLOYMENT_SPEC}" <<EOF
+---
+cpi: azure
+properties:
+  uuid: $(bosh status --uuid)
+  stemcell:
+    name: bosh-azure-hyperv-ubuntu-trusty-go_agent
+    version: '0000'
+  vip: $CF_IP_ADDRESS
+  pool_size: 1
+  instances: 1
+  second_static_ip: $BAT_SECOND_STATIC_IP
+  networks:
+  - name: default
+    type: manual
+    static_ip: $BAT_NETWORK_STATIC_IP
+    cloud_properties:
+      virtual_network_name: $AZURE_VNET_NAME
+      subnet_name: $AZURE_CF_SUBNET_NAME
+    cidr: $BAT_NETWORK_CIDR
+    reserved: ['$BAT_NETWORK_RESERVED_RANGE']
+    static: ['$BAT_NETWORK_STATIC_RANGE']
+    gateway: $BAT_NETWORK_GATEWAY
+  - name: static
+    type: vip
+    cloud_properties:
+      tcp_endpoints:
+      - "22:22"
+      - "80:80"
+      - "443:443"
+      - "4222:4222"
+      - "4443:4443"
+  key_name: bosh
+EOF
+echo Using Deployment Spec:
+cat $BAT_DEPLOYMENT_SPEC
+cd bosh
+ls
+# THIS WILL GO AWAY AFTER BATS CODE IS MERGED
+rm .gitmodules
+cat > ".gitmodules" <<EOF
+[submodule "go/src/github.com/cloudfoundry/bosh-agent"]
+      path = go/src/github.com/cloudfoundry/bosh-agent
+      url = https://github.com/AbelHu/bosh-agent.git
+      branch = abelhu
+[submodule "spec/assets/uaa"]
+      path = spec/assets/uaa
+      url = https://github.com/cloudfoundry/uaa.git
+[submodule "bat"]
+      path = bat
+      url = https://github.com/AbelHu/bosh-acceptance-tests.git
+      branch = abelhu
+[submodule "go/src/github.com/cloudfoundry/bosh-davcli"]
+      path = go/src/github.com/cloudfoundry/bosh-davcli
+      url = https://github.com/cloudfoundry/bosh-davcli.git
+EOF
+pwd
+echo cat .gitmodules
+cat .gitmodules
+rm .git/config
+cat > ".git/config" <<EOF
+[core]
+  repositoryformatversion = 0
+  filemode = true
+  bare = false
+  logallrefupdates = true
+[remote "origin"]
+  url = https://github.com/AbelHu/bosh
+  fetch = +refs/heads/*:refs/remotes/origin/*
+[submodule "bat"]
+  url = https://github.com/AbelHu/bosh-acceptance-tests.git
+  branch = master
+[submodule "go/src/github.com/cloudfoundry/bosh-agent"]
+  url = https://github.com/AbelHu/bosh-agent.git
+  branch = abelhu
+[submodule "spec/assets/uaa"]
+  url = https://github.com/cloudfoundry/uaa.git
+EOF
+cd bat
+git config remote.origin.url https://github.com/AbelHu/bosh-acceptance-tests.git
+cd ..
+pushd go/src/github.com/cloudfoundry/bosh-agent
+git config remote.origin.url https://github.com/AbelHu/bosh-agent.git
+popd
+echo Current Directory:
+echo git submodule update --init
+git submodule update --init
+echo git submodule update --remote
+git submodule update --remote
+#gem uninstall mini_portile -v '0.7.0.rc2' --ignore-dependencies
+#gem install mini_portile -v '0.6.2'
+echo bundle install
+bundle install
+echo bundle exec rake bat:env
+bundle exec rake bat:env
+echo bundle exec rake bat
+bundle exec rake bat

--- a/ci/tasks/run-bats.yml
+++ b/ci/tasks/run-bats.yml
@@ -1,0 +1,26 @@
+---
+platform: linux
+image: docker:///sedouard/azure-cpi-release
+inputs:
+- name: bosh-cpi-dev-artifacts
+- name: stemcell
+- name: bosh-cpi-release
+- name: azure-exports
+- name: bosh
+run:
+  path: bosh-cpi-release/ci/tasks/run-bats.sh
+params:
+  base_os:                      replace-me
+  private_key_data:             replace-me
+  BAT_VCAP_PASSWORD:            replace-me
+  BAT_STEMCELL_URL:             replace-me
+  BAT_STEMCELL_SHA:             replace-me
+  BAT_SECOND_STATIC_IP:         replace-me
+  BAT_NETWORK_STATIC_IP:        replace-me
+  BAT_NETWORK_CIDR:             replace-me
+  BAT_NETWORK_RESERVED_RANGE:   replace-me
+  BAT_NETWORK_STATIC_RANGE:     replace-me
+  BAT_NETWORK_GATEWAY:          replace-me
+  AZURE_VNET_NAME:              replace-me
+  AZURE_CF_SUBNET_NAME:         replace-me
+

--- a/ci/tasks/utils.sh
+++ b/ci/tasks/utils.sh
@@ -1,0 +1,8 @@
+check_param() {
+  local name=$1
+  local value=$(eval echo '$'$name)
+  if [ "$value" == 'replace-me' ]; then
+    echo "environment variable $name must be set"
+    exit 1
+  fi
+}


### PR DESCRIPTION
This is the initial workflow for running BOSH acceptance tests in continuous integration from @ritazh and I.

@ritazh has implemented much of the director deployment, and BATs automation.

Here are a few outstanding things:

- Bosh Acceptance Tests (BATs) are currently coming from https://github.com/AbelHu/bosh-acceptance-tests branch: azure_cpi_external which eventually should come from the CloudFoundry upstream repository.

- The docker repo for the CI container image is at docker://sedouard/azure-cpi-release and should be an official Microsoft or Azure docker repo.

- The gems required for this to work require a patched ruby sdk and patched bosh-azure-cpi which sends a client-side timeout. This will be done by @ritazh.

- A PR to github.com/concourse/concourse will be coming very soon for documentation on running concourse on azure.
